### PR TITLE
Feature/sb 1141 data masking in logs

### DIFF
--- a/force/client.go
+++ b/force/client.go
@@ -158,7 +158,7 @@ func (forceApi *ForceApi) traceRequest(req *http.Request) {
 func (forceApi *ForceApi) traceResponse(resp *http.Response) {
 	if forceApi.logger != nil {
 		url := ""
-		if req.URL != nil {
+		if resp.Request.URL != nil {
 			duplicatedReqURL := *resp.Request.URL
 			duplicatedReqURL.RawQuery = "***"
 			url = duplicatedReqURL.String()

--- a/force/client.go
+++ b/force/client.go
@@ -103,7 +103,6 @@ func (forceApi *ForceApi) request(method, path string, params url.Values, payloa
 	if err != nil {
 		return fmt.Errorf("Error reading response bytes: %v", err)
 	}
-	forceApi.traceResponseBody(respBytes)
 
 	// Attempt to parse response into out
 	var objectUnmarshalErr error
@@ -118,6 +117,7 @@ func (forceApi *ForceApi) request(method, path string, params url.Values, payloa
 	apiErrors := ApiErrors{}
 	if marshalErr := forcejson.Unmarshal(respBytes, &apiErrors); marshalErr == nil {
 		if apiErrors.Validate() {
+			forceApi.traceResponseBody(respBytes)
 			// Check if error is oauth token expired
 			if forceApi.oauth.Expired(apiErrors) {
 				// Reauthenticate then attempt query again
@@ -134,6 +134,7 @@ func (forceApi *ForceApi) request(method, path string, params url.Values, payloa
 	}
 
 	if objectUnmarshalErr != nil {
+		forceApi.traceResponseBody(respBytes)
 		// Not a force.com api error. Just an unmarshalling error.
 		return fmt.Errorf("Unable to unmarshal response to object: %v", objectUnmarshalErr)
 	}
@@ -144,13 +145,25 @@ func (forceApi *ForceApi) request(method, path string, params url.Values, payloa
 
 func (forceApi *ForceApi) traceRequest(req *http.Request) {
 	if forceApi.logger != nil {
-		forceApi.trace("Request:", "%v", req)
+		url := ""
+		if req.URL != nil {
+			duplicatedReqURL := *req.URL
+			duplicatedReqURL.RawQuery = "***Masked***"
+			url = duplicatedReqURL.String()
+		}
+		forceApi.trace("Request:", "%s %s", req.Method, url)
 	}
 }
 
 func (forceApi *ForceApi) traceResponse(resp *http.Response) {
 	if forceApi.logger != nil {
-		forceApi.trace("Response:", "%v", resp)
+		url := ""
+		if req.URL != nil {
+			duplicatedReqURL := *resp.Request.URL
+			duplicatedReqURL.RawQuery = "***"
+			url = duplicatedReqURL.String()
+		}
+		forceApi.trace("Response Status Code:", "(%d) %s %s", resp.StatusCode, resp.Request.Method, url)
 	}
 }
 

--- a/force/client.go
+++ b/force/client.go
@@ -144,18 +144,18 @@ func (forceApi *ForceApi) request(method, path string, params url.Values, payloa
 
 func (forceApi *ForceApi) traceRequest(req *http.Request) {
 	if forceApi.logger != nil {
-		forceApi.trace("Request:", req, "%v")
+		forceApi.trace("Request:", "%v", req)
 	}
 }
 
 func (forceApi *ForceApi) traceResponse(resp *http.Response) {
 	if forceApi.logger != nil {
-		forceApi.trace("Response:", resp, "%v")
+		forceApi.trace("Response:", "%v", resp)
 	}
 }
 
 func (forceApi *ForceApi) traceResponseBody(body []byte) {
 	if forceApi.logger != nil {
-		forceApi.trace("Response Body:", string(body), "%s")
+		forceApi.trace("Response Body:", "%s", string(body))
 	}
 }

--- a/force/client.go
+++ b/force/client.go
@@ -158,9 +158,9 @@ func (forceApi *ForceApi) traceRequest(req *http.Request) {
 func (forceApi *ForceApi) traceResponse(resp *http.Response) {
 	if forceApi.logger != nil {
 		url := ""
-		if resp.Request.URL != nil {
+		if resp.Request != nil && resp.Request.URL != nil {
 			duplicatedReqURL := *resp.Request.URL
-			duplicatedReqURL.RawQuery = "***"
+			duplicatedReqURL.RawQuery = "***Masked***"
 			url = duplicatedReqURL.String()
 		}
 		forceApi.trace("Response Status Code:", "(%d) %s %s", resp.StatusCode, resp.Request.Method, url)

--- a/force/force.go
+++ b/force/force.go
@@ -225,9 +225,11 @@ func (forceApi *ForceApi) TraceOff() {
 	forceApi.logPrefix = ""
 }
 
-func (forceApi *ForceApi) trace(name string, value interface{}, format string) {
+// trace logs the trace message e.g. "(prefix) (description) (value)\n"
+// format should be the string format of the value passed. e.g. "%v"
+func (forceApi *ForceApi) trace(description, format string, value ...interface{}) {
 	if forceApi.logger != nil {
-		logMsg := "%s%s " + format + "\n"
-		forceApi.logger.Printf(logMsg, forceApi.logPrefix, name, value)
+		logMsg := forceApi.logPrefix + description + " " + format + "\n"
+		forceApi.logger.Printf(logMsg, value)
 	}
 }

--- a/force/force.go
+++ b/force/force.go
@@ -230,6 +230,6 @@ func (forceApi *ForceApi) TraceOff() {
 func (forceApi *ForceApi) trace(description, format string, value ...interface{}) {
 	if forceApi.logger != nil {
 		logMsg := forceApi.logPrefix + description + " " + format + "\n"
-		forceApi.logger.Printf(logMsg, value)
+		forceApi.logger.Printf(logMsg, value...)
 	}
 }


### PR DESCRIPTION
Jira Ticket:
https://society1.atlassian.net/browse/SB-1141

Changes:
- Mask request & response logs. Also URL in SOQL query
- Log response body only in unexpected error

New Request & Response log format:
- {"Product":"cloudlending","level":"info","msg":"forceApi Request: GET https://societyone.my.salesforce.com/services/data/v43.0/query?***Masked***\n","time":"2021-04-19T10:05:53.903"}
- {"Product":"cloudlending","level":"info","msg":"forceApi Response Status Code: (200) GET https://societyone.my.salesforce.com/services/data/v43.0/query?***Masked***\n","time":"2021-04-19T10:06:00.202"}
